### PR TITLE
Python versions

### DIFF
--- a/.github/workflows/test_tip.yml
+++ b/.github/workflows/test_tip.yml
@@ -38,6 +38,7 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}  # Use the token here
           fail_ci_if_error: true
 
   test-potential-wheel-install:

--- a/.github/workflows/test_tip.yml
+++ b/.github/workflows/test_tip.yml
@@ -9,7 +9,6 @@ jobs:
       max-parallel: 3
       matrix:
         python-version:
-          - 3.7
           - 3.8
           - 3.9
           - "3.10"

--- a/.github/workflows/test_tip.yml
+++ b/.github/workflows/test_tip.yml
@@ -5,13 +5,22 @@ on: [push, release]
 jobs:
   test-source-install:
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 3
+      matrix:
+        python-version:
+          - 3.7
+          - 3.8
+          - 3.9
+          - "3.10"
+          - "3.11"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -26,6 +35,7 @@ jobs:
           coverage report
           coverage xml -o coverage.xml
       - name: Upload to Codecov
+        if: matrix.python-version == '3.9'
         uses: codecov/codecov-action@v2
         with:
           files: coverage.xml

--- a/.github/workflows/test_tip.yml
+++ b/.github/workflows/test_tip.yml
@@ -1,12 +1,6 @@
 ---
 name: Source
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - '*'
+on: [push, release]
 
 jobs:
   test-source-install:
@@ -22,12 +16,20 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install coverage pytest-cov
       - name: Install package from source
         run: pip install -e .
       - name: Test package from source
         run: |
           python -c "import paperscraper"
-          python -m pytest -sv paperscraper
+          coverage run -m pytest -sv paperscraper
+          coverage report
+          coverage xml -o coverage.xml
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          files: coverage.xml
+          fail_ci_if_error: true
 
   test-potential-wheel-install:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_tip.yml
+++ b/.github/workflows/test_tip.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -28,6 +28,7 @@ jobs:
         run: |
           python -c "import paperscraper"
           python -m pytest -sv paperscraper
+
   test-potential-wheel-install:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
-[![build](https://github.com/PhosphorylatedRabbits/paperscraper/actions/workflows/test_tip.yml/badge.svg?branch=main)](https://github.com/PhosphorylatedRabbits/paperscraper/actions/workflows/test_tip.yml?query=branch%3Amain)
-[![build](https://github.com/PhosphorylatedRabbits/paperscraper/actions/workflows/test_pypi.yml/badge.svg?branch=main)](https://github.com/PhosphorylatedRabbits/paperscraper/actions/workflows/test_pypi.yml?query=branch%3Amain)
+[![build](https://github.com/jannisborn/paperscraper/actions/workflows/test_tip.yml/badge.svg?branch=main)](https://github.com/jannisborn/paperscraper/actions/workflows/test_tip.yml?query=branch%3Amain)
+[![build](https://github.com/jannisborn/paperscraper/actions/workflows/test_pypi.yml/badge.svg?branch=main)](https://github.com/jannisborn/paperscraper/actions/workflows/test_pypi.yml?query=branch%3Amain)
 [![License:
 MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PyPI version](https://badge.fury.io/py/paperscraper.svg)](https://badge.fury.io/py/paperscraper)
@@ -246,7 +246,7 @@ plot_comparison(
 )
 ```
 
-![molreps](https://github.com/PhosphorylatedRabbits/paperscraper/blob/master/assets/molreps.png "MolReps")
+![molreps](https://github.com/jannisborn/paperscraper/blob/master/assets/molreps.png "MolReps")
 
 
 #### Venn Diagrams
@@ -264,7 +264,7 @@ labels_2019 = ['Medical Imaging', 'Artificial\nIntelligence']
 plot_venn_two(sizes_2019, labels_2019, title='2019', figname='ai_imaging')
 ```
 
-![2019](https://github.com/PhosphorylatedRabbits/paperscraper/blob/master/assets/ai_imaging.png "2019")
+![2019](https://github.com/jannisborn/paperscraper/blob/master/assets/ai_imaging.png "2019")
 
 
 ```py
@@ -273,7 +273,7 @@ plot_venn_three(
 )
 ```
 
-![2020](https://github.com/PhosphorylatedRabbits/paperscraper/blob/master/assets/ai_imaging_covid.png "2020"))
+![2020](https://github.com/jannisborn/paperscraper/blob/master/assets/ai_imaging_covid.png "2020"))
 
 Or plot both together:
 
@@ -286,7 +286,7 @@ plot_multiple_venn(
 )
 ```
 
-![both](https://github.com/PhosphorylatedRabbits/paperscraper/blob/master/assets/both.png "Both")
+![both](https://github.com/jannisborn/paperscraper/blob/master/assets/both.png "Both")
 
 
 

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.or
 [![Downloads](https://static.pepy.tech/badge/paperscraper)](https://pepy.tech/project/paperscraper)
 [![Downloads](https://static.pepy.tech/badge/paperscraper/month)](https://pepy.tech/project/paperscraper)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![codecov](https://codecov.io/github/jannisborn/paperscraper/graph/badge.svg?token=Clwi0pu61a)](https://codecov.io/github/jannisborn/paperscraper)
 
 # paperscraper
 
-## Overview
-
-`paperscraper` is a `python` package that ships via `pypi` and facilitates scraping
-publication metadata as well as full PDF files from **PubMed** or from preprint servers such as **arXiv**,
-**medRxiv**, **bioRxiv** and **chemRxiv**. It provides a streamlined interface to scrape metadata and comes
-with simple postprocessing functions and plotting routines for meta-analysis.
+`paperscraper` is a `python` package for scraping publication metadata or full PDF files from
+**PubMed** or preprint servers such as **arXiv**, **medRxiv**, **bioRxiv** and **chemRxiv**.
+It provides a streamlined interface to scrape metadata, allows to retrieve citation counts
+from Google Scholar, impact factors from journals and comes with simple postprocessing functions
+and plotting routines for meta-analysis.
 
 
 ## Getting started

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,10 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )


### PR DESCRIPTION
Python 3.7 is no longer supported by paperscraper.

But we now test and support 3.8+, including also 3.11

Plus integration of CodeCov + Badge