### PR TITLE
Refactor to pymed-paperscraper as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ plot_comparison(
 )
 ```
 
-![molreps](https://github.com/jannisborn/paperscraper/blob/master/assets/molreps.png?raw=true "MolReps")
+![molreps](https://github.com/jannisborn/paperscraper/blob/main/assets/molreps.png?raw=true "MolReps")
 
 
 #### Venn Diagrams
@@ -261,7 +261,7 @@ labels_2019 = ['Medical Imaging', 'Artificial\nIntelligence']
 plot_venn_two(sizes_2019, labels_2019, title='2019', figname='ai_imaging')
 ```
 
-![2019](https://github.com/jannisborn/paperscraper/blob/master/assets/ai_imaging.png?raw=true "2019")
+![2019](https://github.com/jannisborn/paperscraper/blob/main/assets/ai_imaging.png?raw=true "2019")
 
 
 ```py
@@ -270,7 +270,7 @@ plot_venn_three(
 )
 ```
 
-![2020](https://github.com/jannisborn/paperscraper/blob/master/assets/ai_imaging_covid.png?raw=true "2020"))
+![2020](https://github.com/jannisborn/paperscraper/blob/main/assets/ai_imaging_covid.png?raw=true "2020")
 
 Or plot both together:
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ But watch out. The resulting `.jsonl` file will be labelled according to the cur
 
 ## Examples
 
-`paperscraper` is build on top of the packages [pymed](https://pypi.org/project/pymed/),
-[arxiv](https://pypi.org/project/arxiv/) and [scholarly](https://pypi.org/project/scholarly/). 
+`paperscraper` is build on top of the packages [arxiv](https://pypi.org/project/arxiv/), [pymed](https://pypi.org/project/pymed-paperscraper/), and [scholarly](https://pypi.org/project/scholarly/). 
 
 ### Publication keyword search
 

--- a/paperscraper/__init__.py
+++ b/paperscraper/__init__.py
@@ -1,7 +1,7 @@
 """Initialize the module."""
 
 __name__ = "paperscraper"
-__version__ = "0.2.13"
+__version__ = "0.2.14"
 
 import logging
 import os

--- a/paperscraper/pubmed/pubmed.py
+++ b/paperscraper/pubmed/pubmed.py
@@ -3,7 +3,7 @@ import logging
 from typing import List, Union
 
 import pandas as pd
-from pymed import PubMed
+from pymed_paperscraper import PubMed
 
 from ..utils import dump_papers
 from .utils import get_emails, get_query_from_keywords_and_date

--- a/paperscraper/pubmed/tests/test_pubmed.py
+++ b/paperscraper/pubmed/tests/test_pubmed.py
@@ -1,8 +1,5 @@
 import os
 import tempfile
-from unittest.mock import patch
-
-import pytest
 
 from paperscraper.pubmed import get_and_dump_pubmed_papers, get_pubmed_papers
 from paperscraper.pubmed.utils import get_query_from_keywords_and_date
@@ -32,3 +29,9 @@ class TestPubMed:
         )
         df = get_pubmed_papers(query, fields=["emails", "title", "authors"])
         assert "emails" in df.columns
+
+
+if __name__ == "__main__":
+    t = TestPubMed()
+    t.test_get_and_dump_pubmed()
+    t.test_email()

--- a/paperscraper/pubmed/utils.py
+++ b/paperscraper/pubmed/utils.py
@@ -1,7 +1,7 @@
 import warnings
 from typing import List, Union
 
-from pymed.article import PubMedArticle
+from pymed_paperscraper.article import PubMedArticle
 
 finalize_disjunction = lambda x: "(" + x[:-4] + ") AND "
 finalize_conjunction = lambda x: x[:-5]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arxiv>=1.4.7
-pybmed-paperscraper==1.0.0
+pymed-paperscraper
 pandas>=1.0.4
 requests==2.32.0
 tqdm>=4.51.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arxiv>=1.4.7
-pymed==0.8.9
+pybmed-paperscraper==1.0.0
 pandas>=1.0.4
 requests==2.32.0
 tqdm>=4.51.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     license="MIT",
     install_requires=[
         "arxiv>=1.4.2",
-        "pymed",
+        "pymed-paperscraper",
         "pandas",
         "requests",
         "tqdm",


### PR DESCRIPTION
Since pymed is archived and has occasional issues with url errors due to too aggressive API submissions, I forked it into pymed-paperscraper, introduced wait times between API requests and are now changing this dependency in paperscraper