### PR TITLE
feat: support date search in arxiv

### DIFF
--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -5,10 +5,10 @@ jobs:
   verify-current-pypi:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install package from PyPI
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test_tip.yml
+++ b/.github/workflows/test_tip.yml
@@ -9,7 +9,6 @@ jobs:
       max-parallel: 3
       matrix:
         python-version:
-          - 3.8
           - 3.9
           - "3.10"
           - "3.11"
@@ -34,7 +33,7 @@ jobs:
           coverage report
           coverage xml -o coverage.xml
       - name: Upload to Codecov
-        if: matrix.python-version == '3.8'
+        if: matrix.python-version == '3.9'
         uses: codecov/codecov-action@v2
         with:
           files: coverage.xml
@@ -50,10 +49,10 @@ jobs:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install dependencies
       run: |

--- a/paperscraper/arxiv/arxiv.py
+++ b/paperscraper/arxiv/arxiv.py
@@ -29,6 +29,7 @@ def get_arxiv_papers(
     max_results: int = 99999,
     client_options: Dict = {"num_retries": 10},
     search_options: Dict = dict(),
+    verbose: bool = True,
 ) -> pd.DataFrame:
     """
     Performs arxiv API request of a given query and returns list of papers with
@@ -62,7 +63,7 @@ def get_arxiv_papers(
                 for key, value in vars(paper).items()
                 if arxiv_field_mapper.get(key, key) in fields and key != "doi"
             }
-            for paper in tqdm(results, desc=f"Processing {query}")
+            for paper in tqdm(results, desc=f"Processing {query}", disable=not verbose)
         ]
     )
     return processed
@@ -72,6 +73,8 @@ def get_and_dump_arxiv_papers(
     keywords: List[Union[str, List[str]]],
     output_filepath: str,
     fields: List = ["title", "authors", "date", "abstract", "journal", "doi"],
+    start_date: str = "None",
+    end_date: str = "None",
     *args,
     **kwargs,
 ):
@@ -86,9 +89,13 @@ def get_and_dump_arxiv_papers(
         fields (List, optional): List of strings with fields to keep in output.
             Defaults to ['title', 'authors', 'date', 'abstract',
             'journal', 'doi'].
+        start_date (str): Start date for the search. Needs to be in format:
+            YYYY/MM/DD, e.g. '2020/07/20'. Defaults to 'None', i.e. no specific
+            dates are used.
+        end_date (str): End date for the search. Same notation as start_date.
         *args, **kwargs are additional arguments for `get_arxiv_papers`.
     """
     # Translate keywords into query.
-    query = get_query_from_keywords(keywords)
+    query = get_query_from_keywords(keywords, start_date=start_date, end_date=end_date)
     papers = get_arxiv_papers(query, fields, *args, **kwargs)
     dump_papers(papers, output_filepath)

--- a/paperscraper/arxiv/utils.py
+++ b/paperscraper/arxiv/utils.py
@@ -4,12 +4,12 @@ from typing import List, Union
 finalize_disjunction = lambda x: "(" + x[:-4] + ") AND "
 finalize_conjunction = lambda x: x[:-5]
 
-EARLIEST_START = "197001010000"
+EARLIEST_START = "1970-01-01"
 
 
 def format_date(date_str: str) -> str:
-    """Converts a date in YYYY/MM/DD format to arXiv's YYYYMMDDTTTT format."""
-    date_obj = datetime.strptime(date_str, "%Y/%m/%d")
+    """Converts a date in YYYY-MM-DD format to arXiv's YYYYMMDDTTTT format."""
+    date_obj = datetime.strptime(date_str, "%Y-%m-%d")
     return date_obj.strftime("%Y%m%d0000")
 
 
@@ -24,7 +24,7 @@ def get_query_from_keywords(
         keywords (List[str, List[str]]): Items will be AND separated. If items
             are lists themselves, they will be OR separated.
         start_date (str): Start date for the search. Needs to be in format:
-            YYYY/MM/DD, e.g. '2020/07/20'. Defaults to 'None', i.e. no specific
+            YYYY-MM-DD, e.g. '2020-07-20'. Defaults to 'None', i.e. no specific
             dates are used.
         end_date (str): End date for the search. Same notation as start_date.
 
@@ -46,7 +46,7 @@ def get_query_from_keywords(
     elif start_date == "None":
         start_date = EARLIEST_START
     elif end_date == "None":
-        end_date = datetime.now().strftime("%Y%m%d2359")
+        end_date = datetime.now().strftime("%Y-%m-%d")
 
     start = format_date(start_date)
     end = format_date(end_date)

--- a/paperscraper/arxiv/utils.py
+++ b/paperscraper/arxiv/utils.py
@@ -1,15 +1,32 @@
+from datetime import datetime
 from typing import List, Union
 
 finalize_disjunction = lambda x: "(" + x[:-4] + ") AND "
 finalize_conjunction = lambda x: x[:-5]
 
+EARLIEST_START = "197001010000"
 
-def get_query_from_keywords(keywords: List[Union[str, List[str]]]) -> str:
+
+def format_date(date_str: str) -> str:
+    """Converts a date in YYYY/MM/DD format to arXiv's YYYYMMDDTTTT format."""
+    date_obj = datetime.strptime(date_str, "%Y/%m/%d")
+    return date_obj.strftime("%Y%m%d0000")
+
+
+def get_query_from_keywords(
+    keywords: List[Union[str, List[str]]],
+    start_date: str = "None",
+    end_date: str = "None",
+) -> str:
     """Receives a list of keywords and returns the query for the arxiv API.
 
     Args:
         keywords (List[str, List[str]]): Items will be AND separated. If items
             are lists themselves, they will be OR separated.
+        start_date (str): Start date for the search. Needs to be in format:
+            YYYY/MM/DD, e.g. '2020/07/20'. Defaults to 'None', i.e. no specific
+            dates are used.
+        end_date (str): End date for the search. Same notation as start_date.
 
     Returns:
         str: query to enter to arxiv API.
@@ -24,4 +41,14 @@ def get_query_from_keywords(keywords: List[Union[str, List[str]]]) -> str:
             query += finalize_disjunction(inter)
 
     query = finalize_conjunction(query)
-    return query
+    if start_date == "None" and end_date == "None":
+        return query
+    elif start_date == "None":
+        start_date = EARLIEST_START
+    elif end_date == "None":
+        end_date = datetime.now().strftime("%Y%m%d2359")
+
+    start = format_date(start_date)
+    end = format_date(end_date)
+    date_filter = f" AND submittedDate:[{start} TO {end}]"
+    return query + date_filter

--- a/paperscraper/pdf.py
+++ b/paperscraper/pdf.py
@@ -47,7 +47,7 @@ def save_pdf(
     output_path = Path(filepath)
 
     if not Path(output_path).parent.exists():
-        raise ValueError(f"The folder: {output_path.parent} seems to not exist.")
+        raise ValueError(f"The folder: {output_path} seems to not exist.")
 
     url = f"https://doi.org/{paper_metadata['doi']}"
     try:

--- a/paperscraper/tests/test_dump.py
+++ b/paperscraper/tests/test_dump.py
@@ -92,18 +92,18 @@ class TestDumper:
         get_and_dump_arxiv_papers(
             [["MPEGO"]],
             output_filepath="mpego.jsonl",
-            begin_date="2020-06-01",
+            start_date="2020-06-01",
             end_date="2024-06-02",
         )
         get_and_dump_arxiv_papers(
             [["PaccMann"]],
             output_filepath="paccmann.jsonl",
-            end_date="2024-06-02",
+            end_date="2023-06-02",
         )
         get_and_dump_arxiv_papers(
             [["QontOT"]],
             output_filepath="qontot.jsonl",
-            begin_date="2024-06-02",
+            start_date="2023-01-02",
         )
 
     def test_dump_existence(self):

--- a/paperscraper/tests/test_dump.py
+++ b/paperscraper/tests/test_dump.py
@@ -1,16 +1,15 @@
-import logging
 import importlib
+import logging
 import os
 import threading
 
 import pytest
 
+import paperscraper.load_dumps as load_dumps_module
 from paperscraper import dump_queries
 from paperscraper.arxiv import get_and_dump_arxiv_papers
 from paperscraper.get_dumps import biorxiv, chemrxiv, medrxiv
 from paperscraper.load_dumps import QUERY_FN_DICT
-import paperscraper.load_dumps as load_dumps_module
-
 
 logging.disable(logging.INFO)
 
@@ -20,11 +19,9 @@ mi = ["Medical imaging"]
 
 
 class TestDumper:
-
     def test_dump_existence_initial(self):
         # This test checks the initial state, should be run first if order matters
         assert len(QUERY_FN_DICT) == 2, "Initial length of QUERY_FN_DICT should be 2"
-
 
     @pytest.fixture
     def setup_medrxiv(self):
@@ -77,7 +74,7 @@ class TestDumper:
 
     def test_chemrxiv_date(self):
         chemrxiv(begin_date="2024-06-01", end_date="2024-06-02")
-    
+
     def test_biorxiv_date(self):
         biorxiv(begin_date="2024-06-01", end_date="2024-06-02")
 
@@ -91,7 +88,28 @@ class TestDumper:
         get_and_dump_arxiv_papers(query, output_filepath="covid19_ai_imaging.jsonl")
         assert os.path.exists("covid19_ai_imaging.jsonl")
 
+    def test_arxiv_date(self):
+        get_and_dump_arxiv_papers(
+            [["MPEGO"]],
+            output_filepath="mpego.jsonl",
+            begin_date="2020-06-01",
+            end_date="2024-06-02",
+        )
+        get_and_dump_arxiv_papers(
+            [["PaccMann"]],
+            output_filepath="paccmann.jsonl",
+            end_date="2024-06-02",
+        )
+        get_and_dump_arxiv_papers(
+            [["QontOT"]],
+            output_filepath="qontot.jsonl",
+            begin_date="2024-06-02",
+        )
+
     def test_dump_existence(self):
         importlib.reload(load_dumps_module)
         from paperscraper.load_dumps import QUERY_FN_DICT
-        assert len(QUERY_FN_DICT) > 2, "Expected QUERY_FN_DICT to be updated by previous tests"
+
+        assert (
+            len(QUERY_FN_DICT) > 2
+        ), "Expected QUERY_FN_DICT to be updated by previous tests"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arxiv>=1.4.7
-pymed-paperscraper
+pymed-paperscraper>=1.0.1
 pandas>=1.0.4
 requests==2.32.0
 tqdm>=4.51.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     license="MIT",
     install_requires=[
         "arxiv>=1.4.2",
-        "pymed-paperscraper",
+        "pymed-paperscraper>=1.0.1",
         "pandas",
         "requests",
         "tqdm",
@@ -41,7 +41,7 @@ setup(
         "thefuzz",
         "pytest",
         "tldextract",
-        "semanticscholar"
+        "semanticscholar",
     ],
     keywords=[
         "Academics",


### PR DESCRIPTION
Like biorxchiv/chemrxiv/medrxiv arxiv can now also be queried with start/end date (given in the same format).
This is supported by the arxiv API directly

Example:

```py
get_and_dump_arxiv_papers(
            [["MPEGO"]],
            output_filepath="mpego.jsonl",
            start_date="2020-06-01",
            end_date="2024-06-02",
        )
```