### PR TITLE
Optionally download bioRxiv PDFs via requester-pays S3 bucket

### DIFF
--- a/.github/workflows/deploy_pypi.yml
+++ b/.github/workflows/deploy_pypi.yml
@@ -13,7 +13,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          # pip install -r requirements.txt # not recommended
           pip install setuptools wheel twine
       - name: Build and publish
         env:

--- a/.github/workflows/test_tip.yml
+++ b/.github/workflows/test_tip.yml
@@ -9,9 +9,7 @@ jobs:
       max-parallel: 3
       matrix:
         python-version:
-          - 3.9
           - "3.10"
-          - "3.11"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -42,7 +40,7 @@ jobs:
           coverage report
           coverage xml -o coverage.xml
       - name: Upload to Codecov
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.10'
         uses: codecov/codecov-action@v2
         with:
           files: coverage.xml
@@ -58,10 +56,10 @@ jobs:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.10
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test_tip.yml
+++ b/.github/workflows/test_tip.yml
@@ -33,6 +33,8 @@ jobs:
         run: |
           echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" >> api_keys.txt
           echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" >> api_keys.txt
+          unset AWS_ACCESS_KEY_ID
+          unset AWS_SECRET_ACCESS_KEY
       - name: Test package from source
         run: |
           python -c "import paperscraper"

--- a/.github/workflows/test_tip.yml
+++ b/.github/workflows/test_tip.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test_tip.yml
+++ b/.github/workflows/test_tip.yml
@@ -26,6 +26,13 @@ jobs:
           pip install coverage pytest-cov
       - name: Install package from source
         run: pip install -e .
+      - name: Export AWS secrets
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" >> api_keys.txt
+          echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" >> api_keys.txt
       - name: Test package from source
         run: |
           python -c "import paperscraper"

--- a/.github/workflows/test_tip.yml
+++ b/.github/workflows/test_tip.yml
@@ -61,6 +61,16 @@ jobs:
       with:
         python-version: "3.10"
 
+    - name: Export AWS secrets
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      run: |
+        echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" >> api_keys.txt
+        echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" >> api_keys.txt
+        unset AWS_ACCESS_KEY_ID
+        unset AWS_SECRET_ACCESS_KEY
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ For more comprehensive access to papers from major publishers, you can provide A
 
 - **Wiley TDM API**: Enables access to [Wiley](https://onlinelibrary.wiley.com/library-info/resources/text-and-datamining) publications (2,000+ journals).
 - **Elsevier TDM API**: Enables access to [Elsevier](https://www.elsevier.com/about/policies-and-standards/text-and-data-mining) publications (The Lancet, Cell, ...).
+- **bioRxiv TDM API** Enable access to [bioRxiv](https://www.biorxiv.org/tdm) publications (since May 2025 bioRxiv is protected with Cloudflare)
 
 To use publisher APIs:
 
@@ -188,7 +189,10 @@ To use publisher APIs:
 ```
 WILEY_TDM_API_TOKEN=your_wiley_token_here
 ELSEVIER_TDM_API_KEY=your_elsevier_key_here
+AWS_ACCESS_KEY_ID=your_aws_access_key_here
+AWS_SECRET_ACCESS_KEY=your_aws_secret_key_here
 ```
+NOTE: The AWS keys can be created in your AWS/IAM account. When creating the key, make sure you tick the `AmazonS3ReadOnlyAccess` permission policy. 
 NOTE: If you name the file `.env` it will be loaded automatically (if it is in the cwd or anywhere above the tree to home).
 
 2. Pass the file path when calling retrieval functions:

--- a/paperscraper/__init__.py
+++ b/paperscraper/__init__.py
@@ -1,7 +1,7 @@
 """Initialize the module."""
 
 __name__ = "paperscraper"
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 import logging
 import os
@@ -36,7 +36,7 @@ def dump_queries(keywords: List[List[Union[str, List[str]]]], dump_root: str) ->
 
     for idx, keyword in enumerate(keywords):
         for db, f in QUERY_FN_DICT.items():
-            logger.info(f" Keyword {idx+1}/{len(keywords)}, DB: {db}")
+            logger.info(f" Keyword {idx + 1}/{len(keywords)}, DB: {db}")
             filename = get_filename_from_query(keyword)
             os.makedirs(os.path.join(dump_root, db), exist_ok=True)
             f(keyword, output_filepath=os.path.join(dump_root, db, filename))

--- a/paperscraper/citations/tests/test_self_citations.py
+++ b/paperscraper/citations/tests/test_self_citations.py
@@ -13,7 +13,6 @@ class TestSelfCitations:
     @pytest.fixture
     def dois(self):
         return [
-            "10.1038/s41467-020-18671-7",
             "10.1038/s41586-023-06600-9",
             "ed69978f1594a4e2b9dccfc950490fa1df817ae8",
         ]
@@ -30,11 +29,14 @@ class TestSelfCitations:
             assert isinstance(author, str)
             assert isinstance(self_cites, float)
             assert self_cites >= 0 and self_cites <= 100
+        time.sleep(5)
 
     def test_multiple_dois(self, dois):
-        result = self_citations_paper(dois[1:])
+        start_time = time.perf_counter()
+        result = self_citations_paper(dois)
+        async_duration = time.perf_counter() - start_time
         assert isinstance(result, list)
-        assert len(result) == len(dois[1:])
+        assert len(result) == len(dois)
         for cit_result in result:
             assert isinstance(cit_result, CitationResult)
             assert isinstance(cit_result.ssid, str)
@@ -46,21 +48,13 @@ class TestSelfCitations:
                 assert isinstance(author, str)
                 assert isinstance(self_cites, float)
                 assert self_cites >= 0 and self_cites <= 100
+        time.sleep(5)
 
-    def test_compare_async_and_sync_performance(self, dois):
-        """
-        Compares the execution time of asynchronous and synchronous `self_references`
-        for a list of DOIs.
-        """
-
-        start_time = time.perf_counter()
-        async_results = self_citations_paper(dois)
-        async_duration = time.perf_counter() - start_time
+        # compare async and sync performance
 
         # Measure synchronous execution time (three independent calls)
         start_time = time.perf_counter()
-        sync_results = [self_citations_paper(doi) for doi in dois]
-
+        sync_result = [self_citations_paper(doi) for doi in dois]
         sync_duration = time.perf_counter() - start_time
 
         print(f"Asynchronous execution time (batch): {async_duration:.2f} seconds")
@@ -74,5 +68,5 @@ class TestSelfCitations:
             f"({sync_duration:.2f}s)"
         )
 
-        for a, s in zip(async_results, sync_results):
+        for a, s in zip(result, sync_result):
             assert a == s, f"{a} vs {s}"

--- a/paperscraper/pdf/__init__.py
+++ b/paperscraper/pdf/__init__.py
@@ -1,0 +1,1 @@
+from .pdf import load_api_keys, save_pdf, save_pdf_from_dump  # noqa

--- a/paperscraper/pdf/fallbacks.py
+++ b/paperscraper/pdf/fallbacks.py
@@ -374,6 +374,8 @@ def find_meca_for_doi(s3_client, bucket: str, key: str, doi_token: str) -> bool:
     with zipfile.ZipFile(io.BytesIO(data)) as z:
         manifest = z.read("manifest.xml")
 
+    # Extract the last part of the DOI (newer DOIs that contain date fail otherwise)
+    doi_token = doi_token.split('.')[-1]
     return doi_token.encode("utf-8") in manifest.lower()
 
 

--- a/paperscraper/pdf/fallbacks.py
+++ b/paperscraper/pdf/fallbacks.py
@@ -1,262 +1,27 @@
 """Functionalities to scrape PDF files of publications."""
 
-import json
+import calendar
+import datetime
+import io
 import logging
-import os
 import re
 import sys
 import time
+import zipfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Callable, Dict, Union
 
+import boto3
 import requests
-import tldextract
-from bs4 import BeautifulSoup
-from dotenv import find_dotenv, load_dotenv
 from lxml import etree
 from tqdm import tqdm
 
-from .utils import load_jsonl
+ELIFE_XML_INDEX = None  # global variable to cache the eLife XML index from GitHub
 
+logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-ABSTRACT_ATTRIBUTE = {
-    "biorxiv": ["DC.Description"],
-    "arxiv": ["citation_abstract"],
-    "chemrxiv": ["citation_abstract"],
-}
-DEFAULT_ATTRIBUTES = ["citation_abstract", "description"]
-
-
-def save_pdf(
-    paper_metadata: Dict[str, Any],
-    filepath: str,
-    save_metadata: bool = False,
-    api_keys: Optional[Union[str, Dict[str, str]]] = None,
-) -> None:
-    """
-    Save a PDF file of a paper.
-
-    Args:
-        paper_metadata: A dictionary with the paper metadata. Must contain the `doi` key.
-        filepath: Path to the PDF file to be saved (with or without suffix).
-        save_metadata: A boolean indicating whether to save paper metadata as a separate json.
-        api_keys: Either a dictionary containing API keys (if already loaded) or a string (path to API keys file).
-                  If None, will try to load from `.env` file and if unsuccessful, skip API-based fallbacks.
-    """
-    if not isinstance(paper_metadata, Dict):
-        raise TypeError(f"paper_metadata must be a dict, not {type(paper_metadata)}.")
-    if "doi" not in paper_metadata.keys():
-        raise KeyError("paper_metadata must contain the key 'doi'.")
-    if not isinstance(filepath, str):
-        raise TypeError(f"filepath must be a string, not {type(filepath)}.")
-
-    output_path = Path(filepath)
-
-    if not Path(output_path).parent.exists():
-        raise ValueError(f"The folder: {output_path} seems to not exist.")
-
-    # load API keys from file if not already loaded via in save_pdf_from_dump (dict)
-    if not isinstance(api_keys, dict):
-        api_keys = load_api_keys(api_keys)
-
-    url = f"https://doi.org/{paper_metadata['doi']}"
-    try:
-        response = requests.get(url, timeout=60)
-        response.raise_for_status()
-    except Exception as e:
-        logger.warning(
-            f"Could not download from: {url} - {e}. Attempting download via BioC-PMC fallback"
-        )
-        # always first try fallback to BioC-PMC (open access papers on PubMed Central)
-        success = fallback_bioc_pmc(paper_metadata["doi"], output_path)
-
-        # if BioC-PMC fails, try other fallbacks
-        if not success:
-            # check for specific publishers
-            if "elife" in str(e).lower():  # elife has an open XML repository on GitHub
-                fallback_elife_xml(paper_metadata["doi"], output_path)
-            elif (
-                ("wiley" in str(e).lower())
-                and api_keys
-                and ("WILEY_TDM_API_TOKEN" in api_keys)
-            ):
-                fallback_wiley_api(paper_metadata, output_path, api_keys)
-        return
-
-    soup = BeautifulSoup(response.text, features="lxml")
-    meta_pdf = soup.find("meta", {"name": "citation_pdf_url"})
-    if meta_pdf and meta_pdf.get("content"):
-        pdf_url = meta_pdf.get("content")
-        try:
-            response = requests.get(pdf_url, timeout=60)
-            response.raise_for_status()
-
-            if response.content[:4] != b"%PDF":
-                logger.warning(
-                    f"The file from {url} does not appear to be a valid PDF."
-                )
-                success = fallback_bioc_pmc(paper_metadata["doi"], output_path)
-                if not success:
-                    # Check for specific publishers
-                    if "elife" in paper_metadata["doi"].lower():
-                        logger.info("Attempting fallback to eLife XML repository")
-                        fallback_elife_xml(paper_metadata["doi"], output_path)
-                    elif api_keys and "WILEY_TDM_API_TOKEN" in api_keys:
-                        fallback_wiley_api(paper_metadata, output_path, api_keys)
-                    elif api_keys and "ELSEVIER_TDM_API_KEY" in api_keys:
-                        fallback_elsevier_api(paper_metadata, output_path, api_keys)
-            else:
-                with open(output_path.with_suffix(".pdf"), "wb+") as f:
-                    f.write(response.content)
-        except Exception as e:
-            logger.warning(f"Could not download {pdf_url}: {e}")
-    else:  # if no citation_pdf_url meta tag found, try other fallbacks
-        if "elife" in paper_metadata["doi"].lower():
-            logger.info(
-                "DOI contains eLife, attempting fallback to eLife XML repository on GitHub."
-            )
-            if not fallback_elife_xml(paper_metadata["doi"], output_path):
-                logger.warning(
-                    f"eLife XML fallback failed for {paper_metadata['doi']}."
-                )
-        elif (
-            api_keys and "ELSEVIER_TDM_API_KEY" in api_keys
-        ):  # elsevier journals can be accessed via the Elsevier TDM API (requires API key)
-            fallback_elsevier_api(paper_metadata, output_path, api_keys)
-        else:
-            logger.warning(
-                f"Retrieval failed. No citation_pdf_url meta tag found for {url} and no applicable fallback mechanism available."
-            )
-
-    if not save_metadata:
-        return
-
-    metadata = {}
-    # Extract title
-    title_tag = soup.find("meta", {"name": "citation_title"})
-    metadata["title"] = title_tag.get("content") if title_tag else "Title not found"
-
-    # Extract authors
-    authors = []
-    for author_tag in soup.find_all("meta", {"name": "citation_author"}):
-        if author_tag.get("content"):
-            authors.append(author_tag["content"])
-    metadata["authors"] = authors if authors else ["Author information not found"]
-
-    # Extract abstract
-    domain = tldextract.extract(url).domain
-    abstract_keys = ABSTRACT_ATTRIBUTE.get(domain, DEFAULT_ATTRIBUTES)
-
-    for key in abstract_keys:
-        abstract_tag = soup.find("meta", {"name": key})
-        if abstract_tag:
-            raw_abstract = BeautifulSoup(
-                abstract_tag.get("content", "None"), "html.parser"
-            ).get_text(separator="\n")
-            if raw_abstract.strip().startswith("Abstract"):
-                raw_abstract = raw_abstract.strip()[8:]
-            metadata["abstract"] = raw_abstract.strip()
-            break
-
-    if "abstract" not in metadata.keys():
-        metadata["abstract"] = "Abstract not found"
-        logger.warning(f"Could not find abstract for {url}")
-    elif metadata["abstract"].endswith("..."):
-        logger.warning(f"Abstract truncated from {url}")
-
-    # Save metadata to JSON
-    try:
-        with open(output_path.with_suffix(".json"), "w", encoding="utf-8") as f:
-            json.dump(metadata, f, ensure_ascii=False, indent=4)
-    except Exception as e:
-        logger.error(f"Failed to save metadata to {str(output_path)}: {e}")
-
-
-def save_pdf_from_dump(
-    dump_path: str,
-    pdf_path: str,
-    key_to_save: str = "doi",
-    save_metadata: bool = False,
-    api_keys: Optional[str] = None,
-) -> None:
-    """
-    Receives a path to a `.jsonl` dump with paper metadata and saves the PDF files of
-    each paper.
-
-    Args:
-        dump_path: Path to a `.jsonl` file with paper metadata, one paper per line.
-        pdf_path: Path to a folder where the files will be stored.
-        key_to_save: Key in the paper metadata to use as filename.
-            Has to be `doi` or `title`. Defaults to `doi`.
-        save_metadata: A boolean indicating whether to save paper metadata as a separate json.
-        api_keys: Path to a file with API keys. If None, API-based fallbacks will be skipped.
-    """
-
-    if not isinstance(dump_path, str):
-        raise TypeError(f"dump_path must be a string, not {type(dump_path)}.")
-    if not dump_path.endswith(".jsonl"):
-        raise ValueError("Please provide a dump_path with .jsonl extension.")
-
-    if not isinstance(pdf_path, str):
-        raise TypeError(f"pdf_path must be a string, not {type(pdf_path)}.")
-
-    if not isinstance(key_to_save, str):
-        raise TypeError(f"key_to_save must be a string, not {type(key_to_save)}.")
-    if key_to_save not in ["doi", "title", "date"]:
-        raise ValueError("key_to_save must be one of 'doi' or 'title'.")
-
-    papers = load_jsonl(dump_path)
-
-    if not isinstance(api_keys, dict):
-        api_keys = load_api_keys(api_keys)
-
-    pbar = tqdm(papers, total=len(papers), desc="Processing")
-    for i, paper in enumerate(pbar):
-        pbar.set_description(f"Processing paper {i + 1}/{len(papers)}")
-
-        if "doi" not in paper.keys() or paper["doi"] is None:
-            logger.warning(f"Skipping {paper['title']} since no DOI available.")
-            continue
-        filename = paper[key_to_save].replace("/", "_")
-        pdf_file = Path(os.path.join(pdf_path, f"{filename}.pdf"))
-        xml_file = pdf_file.with_suffix(".xml")
-        if pdf_file.exists():
-            logger.info(f"File {pdf_file} already exists. Skipping download.")
-            continue
-        if xml_file.exists():
-            logger.info(f"File {xml_file} already exists. Skipping download.")
-            continue
-        output_path = str(pdf_file)
-        save_pdf(paper, output_path, save_metadata=save_metadata, api_keys=api_keys)
-
-
-def load_api_keys(filepath: Optional[str] = None) -> Dict[str, str]:
-    """
-    Reads API keys from a file and returns them as a dictionary.
-    The file should have each API key on a separate line in the format:
-        KEY_NAME=API_KEY_VALUE
-
-    Example:
-        WILEY_TDM_API_TOKEN=your_wiley_token_here
-        ELSEVIER_TDM_API_KEY=your_elsevier_key_here
-
-    Args:
-        filepath: Optional path to the file containing API keys.
-
-    Returns:
-        Dict[str, str]: A dictionary where keys are API key names and values are their respective API keys.
-    """
-    if filepath:
-        load_dotenv(dotenv_path=filepath)
-    else:
-        load_dotenv(find_dotenv())
-
-    return {
-        "WILEY_TDM_API_TOKEN": os.getenv("WILEY_TDM_API_TOKEN"),
-        "ELSEVIER_TDM_API_KEY": os.getenv("ELSEVIER_TDM_API_KEY"),
-    }
 
 
 def fallback_wiley_api(
@@ -491,9 +256,6 @@ def fallback_elife_xml(doi: str, output_path: Path) -> bool:
     return True
 
 
-ELIFE_XML_INDEX = None  # global variable to cache the eLife XML index from GitHub
-
-
 def get_elife_xml_index() -> dict:
     """
     Fetch the eLife XML index from GitHub and return it as a dictionary.
@@ -534,3 +296,166 @@ def get_elife_xml_index() -> dict:
         for key in ELIFE_XML_INDEX:
             ELIFE_XML_INDEX[key].sort(key=lambda x: x[0])
     return ELIFE_XML_INDEX
+
+
+def month_folder(doi: str) -> str:
+    """
+    Query bioRxiv API to get the posting date of a given DOI.
+    Convert a date to the BioRxiv S3 folder name, rolling over if it's the month's last day.
+    E.g., if date is the last day of April, treat as May_YYYY.
+
+    Args:
+        doi: The DOI for which to retrieve the date.
+
+    Returns:
+        Month and year in format `October_2019`
+    """
+    url = f"https://api.biorxiv.org/details/biorxiv/{doi}/na/json"
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    date_str = resp.json()["collection"][0]["date"]
+    date = datetime.date.fromisoformat(date_str)
+
+    # NOTE: bioRxiv papers posted on the last day of the month are archived the next day
+    last_day = calendar.monthrange(date.year, date.month)[1]
+    if date.day == last_day:
+        date = date + datetime.timedelta(days=1)
+    return date.strftime("%B_%Y")
+
+
+def list_meca_keys(s3_client, bucket: str, prefix: str) -> list:
+    """
+    List all .meca object keys under a given prefix in a requester-pays bucket.
+
+    Args:
+        s3_client: S3 client to get the data from.
+        bucket: bucket to get data from.
+        prefix: prefix to get data from.
+
+    Returns:
+        List of keys, one per existing .meca in the bucket.
+    """
+    keys = []
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(
+        Bucket=bucket, Prefix=prefix, RequestPayer="requester"
+    ):
+        for obj in page.get("Contents", []):
+            if obj["Key"].endswith(".meca"):
+                keys.append(obj["Key"])
+    return keys
+
+
+def find_meca_for_doi(s3_client, bucket: str, key: str, doi_token: str) -> bool:
+    """
+    Efficiently inspect manifest.xml within a .meca zip by fetching only necessary bytes.
+    Parse via ZipFile to read manifest.xml and match DOI token.
+
+    Args:
+        s3_client: S3 client to get the data from.
+        bucket: bucket to get data from.
+        key: prefix to get data from.
+        doi_token: the DOI that should be matched
+
+    Returns:
+        Whether or not the DOI could be matched
+    """
+    try:
+        head = s3_client.get_object(
+            Bucket=bucket, Key=key, Range="bytes=0-4095", RequestPayer="requester"
+        )["Body"].read()
+        tail = s3_client.get_object(
+            Bucket=bucket, Key=key, Range="bytes=-4096", RequestPayer="requester"
+        )["Body"].read()
+    except Exception:
+        return False
+
+    data = head + tail
+    with zipfile.ZipFile(io.BytesIO(data)) as z:
+        manifest = z.read("manifest.xml")
+
+    return doi_token.encode("utf-8") in manifest.lower()
+
+
+def fallback_s3(
+    doi: str, output_path: Union[str, Path], api_keys: dict, workers: int = 32
+) -> bool:
+    """
+    Download a BioRxiv PDF via the requester-pays S3 bucket using range requests.
+
+    Args:
+        doi: The DOI for which to retrieve the PDF (e.g. '10.1101/798496').
+        output_path: Path where the PDF will be saved (with .pdf suffix added).
+        api_keys: Dict containing 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_ACCESS_KEY'.
+
+    Returns:
+        True if download succeeded, False otherwise.
+    """
+
+    s3 = boto3.client(
+        "s3",
+        aws_access_key_id=api_keys.get("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=api_keys.get("AWS_SECRET_ACCESS_KEY"),
+        region_name="us-east-1",
+    )
+    bucket = "biorxiv-src-monthly"
+
+    # Derive prefix from DOI date
+    prefix = f"Current_Content/{month_folder(doi)}/"
+
+    # List MECA archives in that month
+    meca_keys = list_meca_keys(s3, bucket, prefix)
+    if not meca_keys:
+        return False
+
+    token = doi.split("/")[-1].lower()
+    target = None
+    executor = ThreadPoolExecutor(max_workers=32)
+    futures = {
+        executor.submit(find_meca_for_doi, s3, bucket, key, token): key
+        for key in meca_keys
+    }
+    target = None
+    for future in tqdm(
+        as_completed(futures),
+        total=len(futures),
+        desc=f"Scanning in biorxiv with {workers} workers for {doi}...",
+    ):
+        key = futures[future]
+        try:
+            if future.result():
+                target = key
+                # cancel pending futures to speed shutdown
+                for fut in futures:
+                    fut.cancel()
+                break
+        except Exception:
+            continue
+    # shutdown without waiting for remaining threads
+    executor.shutdown(wait=False)
+    if target is None:
+        logger.error(f"Could not find {doi} on biorxiv")
+        return False
+
+    # Download full MECA and extract PDF
+    data = s3.get_object(Bucket=bucket, Key=target, RequestPayer="requester")[
+        "Body"
+    ].read()
+    output_path = Path(output_path)
+    with zipfile.ZipFile(io.BytesIO(data)) as z:
+        for name in z.namelist():
+            if name.lower().endswith(".pdf"):
+                z.extract(name, path=output_path.parent)
+                # Move file to desired location
+                (output_path.parent / name).rename(output_path.with_suffix(".pdf"))
+                return True
+    return False
+
+
+FALLBACKS: Dict[str, Callable] = {
+    "bioc_pmc": fallback_bioc_pmc,
+    "elife": fallback_elife_xml,
+    "elsevier": fallback_elsevier_api,
+    "s3": fallback_s3,
+    "wiley": fallback_wiley_api,
+}

--- a/paperscraper/pdf/fallbacks.py
+++ b/paperscraper/pdf/fallbacks.py
@@ -416,15 +416,16 @@ def fallback_s3(
         for key in meca_keys
     }
     target = None
-    for future in tqdm(
-        as_completed(futures),
+    pbar = tqdm(
         total=len(futures),
-        desc=f"Scanning in biorxiv with {workers} workers for {doi}...",
-    ):
+        desc=f"Scanning in biorxiv with {workers} workers for {doi}…",
+    )
+    for future in as_completed(futures):
         key = futures[future]
         try:
             if future.result():
                 target = key
+                pbar.set_description(f"Success! Found target {doi} in {key}")
                 # cancel pending futures to speed shutdown
                 for fut in futures:
                     fut.cancel()

--- a/paperscraper/pdf/fallbacks.py
+++ b/paperscraper/pdf/fallbacks.py
@@ -431,7 +431,9 @@ def fallback_s3(
                     fut.cancel()
                 break
         except Exception:
-            continue
+            pass
+        finally:
+            pbar.update(1)
     # shutdown without waiting for remaining threads
     executor.shutdown(wait=False)
     if target is None:

--- a/paperscraper/pdf/pdf.py
+++ b/paperscraper/pdf/pdf.py
@@ -1,0 +1,250 @@
+"""Functionalities to scrape PDF files of publications."""
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+import requests
+import tldextract
+from bs4 import BeautifulSoup
+from tqdm import tqdm
+
+from ..utils import load_jsonl
+from .fallbacks import FALLBACKS
+from .utils import load_api_keys
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+ABSTRACT_ATTRIBUTE = {
+    "biorxiv": ["DC.Description"],
+    "arxiv": ["citation_abstract"],
+    "chemrxiv": ["citation_abstract"],
+}
+DEFAULT_ATTRIBUTES = ["citation_abstract", "description"]
+
+
+def save_pdf(
+    paper_metadata: Dict[str, Any],
+    filepath: Union[str, Path],
+    save_metadata: bool = False,
+    api_keys: Optional[Union[str, Dict[str, str]]] = None,
+) -> None:
+    """
+    Save a PDF file of a paper.
+
+    Args:
+        paper_metadata: A dictionary with the paper metadata. Must contain the `doi` key.
+        filepath: Path to the PDF file to be saved (with or without suffix).
+        save_metadata: A boolean indicating whether to save paper metadata as a separate json.
+        api_keys: Either a dictionary containing API keys (if already loaded) or a string (path to API keys file).
+                  If None, will try to load from `.env` file and if unsuccessful, skip API-based fallbacks.
+    """
+    if not isinstance(paper_metadata, Dict):
+        raise TypeError(f"paper_metadata must be a dict, not {type(paper_metadata)}.")
+    if "doi" not in paper_metadata.keys():
+        raise KeyError("paper_metadata must contain the key 'doi'.")
+    if not isinstance(filepath, str):
+        raise TypeError(f"filepath must be a string, not {type(filepath)}.")
+
+    output_path = Path(filepath)
+
+    if not Path(output_path).parent.exists():
+        raise ValueError(f"The folder: {output_path} seems to not exist.")
+
+    # load API keys from file if not already loaded via in save_pdf_from_dump (dict)
+    if not isinstance(api_keys, dict):
+        api_keys = load_api_keys(api_keys)
+
+    doi = paper_metadata["doi"]
+    url = f"https://doi.org/{doi}"
+    success = False
+    try:
+        response = requests.get(url, timeout=60)
+        response.raise_for_status()
+        success = True
+    except Exception as e:
+        error = str(e)
+        logger.warning(f"Could not download from: {url} - {e}. ")
+
+    if not success and "biorxiv" in error:
+        if (
+            api_keys.get("AWS_ACCESS_KEY_ID") is None
+            or api_keys.get("AWS_SECRET_ACCESS_KEY") is None
+        ):
+            logger.info(
+                "BiorXiv PDFs can be downloaded from a S3 bucket with a requester-pay option. "
+                "Consider setting `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to use this option. "
+                "Pricing is a few cent per GB, thus each request costs < 0.1 cents. "
+                "For details see: https://www.biorxiv.org/tdm"
+            )
+        else:
+            success = FALLBACKS["s3"](doi, output_path, api_keys)
+            if success:
+                return
+
+    if not success:
+        # always first try fallback to BioC-PMC (open access papers on PubMed Central)
+        success = FALLBACKS["bioc_pmc"](doi, output_path)
+
+        # if BioC-PMC fails, try other fallbacks
+        if not success:
+            # check for specific publishers
+            if "elife" in error.lower():  # elife has an open XML repository on GitHub
+                FALLBACKS["elife"](doi, output_path)
+            elif (
+                ("wiley" in error.lower())
+                and api_keys
+                and ("WILEY_TDM_API_TOKEN" in api_keys)
+            ):
+                FALLBACKS["wiley"](paper_metadata, output_path, api_keys)
+        return
+
+    soup = BeautifulSoup(response.text, features="lxml")
+    meta_pdf = soup.find("meta", {"name": "citation_pdf_url"})
+    if meta_pdf and meta_pdf.get("content"):
+        pdf_url = meta_pdf.get("content")
+        try:
+            response = requests.get(pdf_url, timeout=60)
+            response.raise_for_status()
+
+            if response.content[:4] != b"%PDF":
+                logger.warning(
+                    f"The file from {url} does not appear to be a valid PDF."
+                )
+                success = FALLBACKS["bioc_pmc"](doi, output_path)
+                if not success:
+                    # Check for specific publishers
+                    if "elife" in doi.lower():
+                        logger.info("Attempting fallback to eLife XML repository")
+                        FALLBACKS["elife"](doi, output_path)
+                    elif api_keys and "WILEY_TDM_API_TOKEN" in api_keys:
+                        FALLBACKS["wiley"](paper_metadata, output_path, api_keys)
+                    elif api_keys and "ELSEVIER_TDM_API_KEY" in api_keys:
+                        FALLBACKS["elsevier"](paper_metadata, output_path, api_keys)
+            else:
+                with open(output_path.with_suffix(".pdf"), "wb+") as f:
+                    f.write(response.content)
+        except Exception as e:
+            logger.warning(f"Could not download {pdf_url}: {e}")
+    else:  # if no citation_pdf_url meta tag found, try other fallbacks
+        if "elife" in doi.lower():
+            logger.info(
+                "DOI contains eLife, attempting fallback to eLife XML repository on GitHub."
+            )
+            if not FALLBACKS["elive"](doi, output_path):
+                logger.warning(
+                    f"eLife XML fallback failed for {paper_metadata['doi']}."
+                )
+        elif (
+            api_keys and "ELSEVIER_TDM_API_KEY" in api_keys
+        ):  # elsevier journals can be accessed via the Elsevier TDM API (requires API key)
+            FALLBACKS["elsevier"](paper_metadata, output_path, api_keys)
+        else:
+            logger.warning(
+                f"Retrieval failed. No citation_pdf_url meta tag found for {url} and no applicable fallback mechanism available."
+            )
+
+    if not save_metadata:
+        return
+
+    metadata = {}
+    # Extract title
+    title_tag = soup.find("meta", {"name": "citation_title"})
+    metadata["title"] = title_tag.get("content") if title_tag else "Title not found"
+
+    # Extract authors
+    authors = []
+    for author_tag in soup.find_all("meta", {"name": "citation_author"}):
+        if author_tag.get("content"):
+            authors.append(author_tag["content"])
+    metadata["authors"] = authors if authors else ["Author information not found"]
+
+    # Extract abstract
+    domain = tldextract.extract(url).domain
+    abstract_keys = ABSTRACT_ATTRIBUTE.get(domain, DEFAULT_ATTRIBUTES)
+
+    for key in abstract_keys:
+        abstract_tag = soup.find("meta", {"name": key})
+        if abstract_tag:
+            raw_abstract = BeautifulSoup(
+                abstract_tag.get("content", "None"), "html.parser"
+            ).get_text(separator="\n")
+            if raw_abstract.strip().startswith("Abstract"):
+                raw_abstract = raw_abstract.strip()[8:]
+            metadata["abstract"] = raw_abstract.strip()
+            break
+
+    if "abstract" not in metadata.keys():
+        metadata["abstract"] = "Abstract not found"
+        logger.warning(f"Could not find abstract for {url}")
+    elif metadata["abstract"].endswith("..."):
+        logger.warning(f"Abstract truncated from {url}")
+
+    # Save metadata to JSON
+    try:
+        with open(output_path.with_suffix(".json"), "w", encoding="utf-8") as f:
+            json.dump(metadata, f, ensure_ascii=False, indent=4)
+    except Exception as e:
+        logger.error(f"Failed to save metadata to {str(output_path)}: {e}")
+
+
+def save_pdf_from_dump(
+    dump_path: str,
+    pdf_path: str,
+    key_to_save: str = "doi",
+    save_metadata: bool = False,
+    api_keys: Optional[str] = None,
+) -> None:
+    """
+    Receives a path to a `.jsonl` dump with paper metadata and saves the PDF files of
+    each paper.
+
+    Args:
+        dump_path: Path to a `.jsonl` file with paper metadata, one paper per line.
+        pdf_path: Path to a folder where the files will be stored.
+        key_to_save: Key in the paper metadata to use as filename.
+            Has to be `doi` or `title`. Defaults to `doi`.
+        save_metadata: A boolean indicating whether to save paper metadata as a separate json.
+        api_keys: Path to a file with API keys. If None, API-based fallbacks will be skipped.
+    """
+
+    if not isinstance(dump_path, str):
+        raise TypeError(f"dump_path must be a string, not {type(dump_path)}.")
+    if not dump_path.endswith(".jsonl"):
+        raise ValueError("Please provide a dump_path with .jsonl extension.")
+
+    if not isinstance(pdf_path, str):
+        raise TypeError(f"pdf_path must be a string, not {type(pdf_path)}.")
+
+    if not isinstance(key_to_save, str):
+        raise TypeError(f"key_to_save must be a string, not {type(key_to_save)}.")
+    if key_to_save not in ["doi", "title", "date"]:
+        raise ValueError("key_to_save must be one of 'doi' or 'title'.")
+
+    papers = load_jsonl(dump_path)
+
+    if not isinstance(api_keys, dict):
+        api_keys = load_api_keys(api_keys)
+
+    pbar = tqdm(papers, total=len(papers), desc="Processing")
+    for i, paper in enumerate(pbar):
+        pbar.set_description(f"Processing paper {i + 1}/{len(papers)}")
+
+        if "doi" not in paper.keys() or paper["doi"] is None:
+            logger.warning(f"Skipping {paper['title']} since no DOI available.")
+            continue
+        filename = paper[key_to_save].replace("/", "_")
+        pdf_file = Path(os.path.join(pdf_path, f"{filename}.pdf"))
+        xml_file = pdf_file.with_suffix(".xml")
+        if pdf_file.exists():
+            logger.info(f"File {pdf_file} already exists. Skipping download.")
+            continue
+        if xml_file.exists():
+            logger.info(f"File {xml_file} already exists. Skipping download.")
+            continue
+        output_path = str(pdf_file)
+        save_pdf(paper, output_path, save_metadata=save_metadata, api_keys=api_keys)

--- a/paperscraper/pdf/utils.py
+++ b/paperscraper/pdf/utils.py
@@ -1,0 +1,33 @@
+import os
+from typing import Dict, Optional
+
+from dotenv import find_dotenv, load_dotenv
+
+
+def load_api_keys(filepath: Optional[str] = None) -> Dict[str, str]:
+    """
+    Reads API keys from a file and returns them as a dictionary.
+    The file should have each API key on a separate line in the format:
+        KEY_NAME=API_KEY_VALUE
+
+    Example:
+        WILEY_TDM_API_TOKEN=your_wiley_token_here
+        ELSEVIER_TDM_API_KEY=your_elsevier_key_here
+
+    Args:
+        filepath: Optional path to the file containing API keys.
+
+    Returns:
+        Dict[str, str]: A dictionary where keys are API key names and values are their respective API keys.
+    """
+    if filepath:
+        load_dotenv(dotenv_path=filepath)
+    else:
+        load_dotenv(find_dotenv())
+
+    return {
+        "WILEY_TDM_API_TOKEN": os.getenv("WILEY_TDM_API_TOKEN"),
+        "ELSEVIER_TDM_API_KEY": os.getenv("ELSEVIER_TDM_API_KEY"),
+        "AWS_ACCESS_KEY_ID": os.getenv("AWS_ACCESS_KEY_ID"),
+        "AWS_SECRET_ACCESS_KEY": os.getenv("AWS_SECRET_ACCESS_KEY"),
+    }

--- a/paperscraper/tests/test_pdf.py
+++ b/paperscraper/tests/test_pdf.py
@@ -47,6 +47,8 @@ class TestPDF:
         # NOTE: Locally this fails but surprisingly the CI does not need to fight with Cloudflare for the moment
         assert os.path.exists("taskload.pdf")
         assert os.path.exists("taskload.json")
+        os.remove("taskload.pdf")
+        os.remove("taskload.json")
 
         # Now try with S3 routine
         keys = load_api_keys("api_keys.txt")
@@ -61,6 +63,11 @@ class TestPDF:
 
         # Test S3 fallback explicitly
         FALLBACKS["s3"](doi="10.1101/786871", output_path="taskload.pdf", api_keys=keys)
+        assert os.path.exists("taskload.pdf")
+        os.remove("taskload.pdf")
+
+        # Test S3 fallback with newer DOIs (including year/month/day)
+        FALLBACKS["s3"](doi="10.1101/2023.10.09.561414", output_path="taskload.pdf", api_keys=keys)
         assert os.path.exists("taskload.pdf")
         os.remove("taskload.pdf")
 

--- a/paperscraper/tests/test_pdf.py
+++ b/paperscraper/tests/test_pdf.py
@@ -6,14 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from paperscraper.pdf import (
-    fallback_bioc_pmc,
-    fallback_elife_xml,
-    fallback_elsevier_api,
-    fallback_wiley_api,
-    save_pdf,
-    save_pdf_from_dump,
-)
+from paperscraper.pdf import load_api_keys, save_pdf, save_pdf_from_dump
+from paperscraper.pdf.fallbacks import FALLBACKS
 
 logging.disable(logging.INFO)
 
@@ -44,12 +38,22 @@ class TestPDF:
         os.remove("kinases.json")
 
         # biorxiv
-        paper_data = {"doi": "10.1101/798496"}
-        save_pdf(paper_data, filepath="taskload.pdf", save_metadata=True)
+        # paper_data = {"doi": "10.1101/798496"}
+        # save_pdf(paper_data, filepath="taskload.pdf", save_metadata=True)
+        # assert not os.path.exists("taskload.pdf")
+        # assert not os.path.exists("taskload.json")
+
+        # Now try with S3 routine
+        keys = load_api_keys("api_keys.txt")
+        print("Keys", keys)
+        save_pdf(
+            {"doi": "10.1101/786871"},
+            filepath="taskload.pdf",
+            save_metadata=False,
+            api_keys=keys,
+        )
         assert os.path.exists("taskload.pdf")
-        assert os.path.exists("taskload.json")
-        os.remove("taskload.pdf")
-        os.remove("taskload.json")
+        exit()
 
         # medrxiv
         paper_data = {"doi": "10.1101/2020.09.02.20187096"}
@@ -261,7 +265,7 @@ class TestPDF:
         test_doi = "10.1038/s41587-022-01613-7"  # Use a DOI known to be in PMC
         output_path = Path("test_bioc_pmc_output")
         try:
-            result = fallback_bioc_pmc(test_doi, output_path)
+            result = FALLBACKS["bioc_pmc"](test_doi, output_path)
             assert result is True
             assert (output_path.with_suffix(".xml")).exists()
             with open(
@@ -278,7 +282,7 @@ class TestPDF:
         """Test BioC-PMC fallback when no PMCID is available."""
         test_doi = "10.1002/smll.202309431"  # This DOI should not have a PMCID
         output_path = Path("test_bioc_pmc_no_pmcid")
-        result = fallback_bioc_pmc(test_doi, output_path)
+        result = FALLBACKS["bioc_pmc"](test_doi, output_path)
         assert result is False
         assert not os.path.exists(output_path.with_suffix(".xml"))
 
@@ -287,7 +291,7 @@ class TestPDF:
         test_doi = "10.7554/eLife.100173"  # Use a DOI known to be in eLife
         output_path = Path("test_elife_xml_output")
         try:
-            result = fallback_elife_xml(test_doi, output_path)
+            result = FALLBACKS["elife"](test_doi, output_path)
             assert result is True
             assert (output_path.with_suffix(".xml")).exists()
             with open(
@@ -306,7 +310,7 @@ class TestPDF:
             "10.7554/eLife.00001"  # Article that doesn't exist in eLife repository
         )
         output_path = Path("test_elife_nonexistent")
-        result = fallback_elife_xml(test_doi, output_path)
+        result = FALLBACKS["elife"](test_doi, output_path)
         # Assertions - should return False and not create a file
         assert result is False
         assert not os.path.exists(output_path.with_suffix(".xml"))
@@ -322,7 +326,7 @@ class TestPDF:
         output_path = Path("test_wiley_output")
         api_keys = {"WILEY_TDM_API_TOKEN": "test_token"}
         try:
-            fallback_wiley_api(paper_metadata, output_path, api_keys)
+            FALLBACKS["wiley"](paper_metadata, output_path, api_keys)
             assert mock_get.called
             mock_get.assert_called_with(
                 "https://api.wiley.com/onlinelibrary/tdm/v1/articles/10.1002%2Fsmll.202309431",
@@ -344,7 +348,7 @@ class TestPDF:
         paper_metadata = {"doi": "10.1002/smll.202309431"}
         output_path = Path("test_wiley_output")
         api_keys = {"WILEY_TDM_API_TOKEN": "INVALID_TEST_KEY_123"}
-        result = fallback_wiley_api(paper_metadata, output_path, api_keys)
+        result = FALLBACKS["wiley"](paper_metadata, output_path, api_keys)
         # Check the result is a boolean
         # will be True if on university network and False otherwise
         assert isinstance(result, bool)
@@ -362,7 +366,7 @@ class TestPDF:
         output_path = Path("test_elsevier_output")
         api_keys = {"ELSEVIER_TDM_API_KEY": "test_key"}
         try:
-            fallback_elsevier_api(paper_metadata, output_path, api_keys)
+            FALLBACKS["elsevier"](paper_metadata, output_path, api_keys)
             assert mock_get.called
             mock_get.assert_called_with(
                 "https://api.elsevier.com/content/article/doi/10.1016/j.xops.2024.100504?apiKey=test_key&httpAccept=text%2Fxml",
@@ -384,7 +388,7 @@ class TestPDF:
         paper_metadata = {"doi": "10.1016/j.xops.2024.100504"}
         output_path = Path("test_elsevier_invalid")
         api_keys = {"ELSEVIER_TDM_API_KEY": "INVALID_TEST_KEY_123"}
-        result = fallback_elsevier_api(paper_metadata, output_path, api_keys)
+        result = FALLBACKS["elsevier"](paper_metadata, output_path, api_keys)
         # Should return False for invalid key
         assert result is False
         assert not output_path.with_suffix(".xml").exists()

--- a/paperscraper/tests/test_pdf.py
+++ b/paperscraper/tests/test_pdf.py
@@ -38,6 +38,8 @@ class TestPDF:
         os.remove("kinases.json")
 
         # biorxiv
+        if os.path.exists("taskload.pdf"):
+            os.remove("taskload.pdf")
         paper_data = {"doi": "10.1101/798496"}
         save_pdf(paper_data, filepath="taskload.pdf", save_metadata=True)
         assert not os.path.exists("taskload.pdf")

--- a/paperscraper/tests/test_pdf.py
+++ b/paperscraper/tests/test_pdf.py
@@ -44,8 +44,9 @@ class TestPDF:
         os.environ.pop("AWS_ACCESS_KEY_ID", None)
         os.environ.pop("AWS_SECRET_ACCESS_KEY", None)
         save_pdf(paper_data, filepath="taskload.pdf", save_metadata=True)
-        assert not os.path.exists("taskload.pdf")
-        assert not os.path.exists("taskload.json")
+        # NOTE: Locally this fails but surprisingly the CI doesnt need to fight with Cloudflare for the moment
+        assert os.path.exists("taskload.pdf")
+        assert os.path.exists("taskload.json")
 
         # Now try with S3 routine
         keys = load_api_keys("api_keys.txt")

--- a/paperscraper/tests/test_pdf.py
+++ b/paperscraper/tests/test_pdf.py
@@ -44,7 +44,7 @@ class TestPDF:
         os.environ.pop("AWS_ACCESS_KEY_ID", None)
         os.environ.pop("AWS_SECRET_ACCESS_KEY", None)
         save_pdf(paper_data, filepath="taskload.pdf", save_metadata=True)
-        # NOTE: Locally this fails but surprisingly the CI doesnt need to fight with Cloudflare for the moment
+        # NOTE: Locally this fails but surprisingly the CI does not need to fight with Cloudflare for the moment
         assert os.path.exists("taskload.pdf")
         assert os.path.exists("taskload.json")
 

--- a/paperscraper/tests/test_pdf.py
+++ b/paperscraper/tests/test_pdf.py
@@ -45,7 +45,6 @@ class TestPDF:
 
         # Now try with S3 routine
         keys = load_api_keys("api_keys.txt")
-        print("Keys", keys)
         save_pdf(
             {"doi": "10.1101/786871"},
             filepath="taskload.pdf",

--- a/paperscraper/tests/test_pdf.py
+++ b/paperscraper/tests/test_pdf.py
@@ -41,6 +41,8 @@ class TestPDF:
         if os.path.exists("taskload.pdf"):
             os.remove("taskload.pdf")
         paper_data = {"doi": "10.1101/798496"}
+        os.environ.pop("AWS_ACCESS_KEY_ID", None)
+        os.environ.pop("AWS_SECRET_ACCESS_KEY", None)
         save_pdf(paper_data, filepath="taskload.pdf", save_metadata=True)
         assert not os.path.exists("taskload.pdf")
         assert not os.path.exists("taskload.json")

--- a/paperscraper/tests/test_pdf.py
+++ b/paperscraper/tests/test_pdf.py
@@ -52,6 +52,7 @@ class TestPDF:
             api_keys=keys,
         )
         assert os.path.exists("taskload.pdf")
+        os.remove("taskload.pdf")
 
         # medrxiv
         paper_data = {"doi": "10.1101/2020.09.02.20187096"}

--- a/paperscraper/tests/test_pdf.py
+++ b/paperscraper/tests/test_pdf.py
@@ -59,6 +59,11 @@ class TestPDF:
         assert os.path.exists("taskload.pdf")
         os.remove("taskload.pdf")
 
+        # Test S3 fallback explicitly
+        FALLBACKS["s3"](doi="10.1101/786871", output_path="taskload.pdf", api_keys=keys)
+        assert os.path.exists("taskload.pdf")
+        os.remove("taskload.pdf")
+
         # medrxiv
         paper_data = {"doi": "10.1101/2020.09.02.20187096"}
         save_pdf(paper_data, filepath="covid_review.pdf", save_metadata=True)

--- a/paperscraper/tests/test_pdf.py
+++ b/paperscraper/tests/test_pdf.py
@@ -38,10 +38,10 @@ class TestPDF:
         os.remove("kinases.json")
 
         # biorxiv
-        # paper_data = {"doi": "10.1101/798496"}
-        # save_pdf(paper_data, filepath="taskload.pdf", save_metadata=True)
-        # assert not os.path.exists("taskload.pdf")
-        # assert not os.path.exists("taskload.json")
+        paper_data = {"doi": "10.1101/798496"}
+        save_pdf(paper_data, filepath="taskload.pdf", save_metadata=True)
+        assert not os.path.exists("taskload.pdf")
+        assert not os.path.exists("taskload.json")
 
         # Now try with S3 routine
         keys = load_api_keys("api_keys.txt")
@@ -53,7 +53,6 @@ class TestPDF:
             api_keys=keys,
         )
         assert os.path.exists("taskload.pdf")
-        exit()
 
         # medrxiv
         paper_data = {"doi": "10.1101/2020.09.02.20187096"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ semanticscholar>=0.8.4
 pydantic
 unidecode
 dotenv
+boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arxiv>=1.4.7
-pymed-paperscraper>=1.0.3
+pymed-paperscraper>=1.0.4
 pandas>=1.0.4
 requests==2.32.0
 tqdm>=4.51.0

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "pydantic",
         "unidecode",
         "dotenv",
+        "boto3",
     ],
     keywords=[
         "Academics",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     license="MIT",
     install_requires=[
         "arxiv>=1.4.2",
-        "pymed-paperscraper>=1.0.3",
+        "pymed-paperscraper>=1.0.4",
         "pandas",
         "requests",
         "tqdm",


### PR DESCRIPTION
Problem: Some users experienced 403 errors from biorxiv since biorxiv started to protect itself with Cloudflare.

Solution: The biorxiv TDM (https://www.biorxiv.org/tdm) gives bulk-access to all PDFs via a requester-pays S3 bucket.
This PR introduces a new fallback mechanism when calling `paperscraper.pdf.save_pdf`. If the provided DOI points to biorxiv and normal scraping of the PDF fails, then the `fallback_s3` function is triggered which retrieves the correct PDF from the S3 bucket. To enable the fallback the user needs to provide AWS credentials in the `.env` file. The needed variables are:
```sh
AWS_ACCESS_KEY_ID=
AWS_SECRET_ACCESS_KEY=
```


