### PR TITLE
Update pdf.py

### DIFF
--- a/paperscraper/pdf/pdf.py
+++ b/paperscraper/pdf/pdf.py
@@ -135,7 +135,7 @@ def save_pdf(
             logger.info(
                 "DOI contains eLife, attempting fallback to eLife XML repository on GitHub."
             )
-            if not FALLBACKS["elive"](doi, output_path):
+            if not FALLBACKS["elife"](doi, output_path):
                 logger.warning(
                     f"eLife XML fallback failed for {paper_metadata['doi']}."
                 )


### PR DESCRIPTION
fix: correct typo 'elive' to 'elife', the correct key for FALLBACK